### PR TITLE
remove unnecessary table indexing && hotfix for libertine mono

### DIFF
--- a/otfl-font-nms.lua
+++ b/otfl-font-nms.lua
@@ -371,10 +371,8 @@ local function load_font(filename, fontnames, newfontnames, texmf)
                 if not fullinfo then
                     return
                 end
-                local index
-                if newstatus[basefile].index[1] then
-                    index = newstatus[basefile].index[1]
-                else
+                local index = newstatus[basefile].index[1]
+                if not index then
                     index = #newmappings+1
                 end
                 newmappings[index]           = fullinfo


### PR DESCRIPTION
this is a fix for
- http://tex.stackexchange.com/questions/110566/libertine-mono-and-lualatex
- a redundant indexing in font-nms
