### PR TITLE
[rfc] remove ``names.scan()``

### DIFF
--- a/luaotfload-database.lua
+++ b/luaotfload-database.lua
@@ -1510,25 +1510,26 @@ save_names = function (fontnames)
     return false
 end
 
-scan_external_dir = function (dir)
-    local old_names, new_names
-    if fonts_loaded then
-        old_names = names.data
-    else
-        old_names = load_names()
-    end
-    new_names = tablecopy(old_names)
-    local n_scanned, n_new = scan_dir(dir, old_names, new_names)
-    names.data = new_names
-    return n_scanned, n_new
-end
+--- is this used anywhere?
+--scan_external_dir = function (dir)
+--    local old_names, new_names
+--    if fonts_loaded then
+--        old_names = names.data
+--    else
+--        old_names = load_names()
+--    end
+--    new_names = tablecopy(old_names)
+--    local n_scanned, n_new = scan_dir(dir, old_names, new_names)
+--    names.data = new_names
+--    return n_scanned, n_new
+--end
 
 --- export functionality to the namespace “fonts.names”
 names.flush_cache                 = flush_cache
 names.save_lookups                = save_lookups
 names.load                        = load_names
 names.save                        = save_names
-names.scan                        = scan_external_dir
+-----.scan                        = scan_external_dir
 names.update                      = update_names
 names.crude_file_lookup           = crude_file_lookup
 names.crude_file_lookup_verbose   = crude_file_lookup_verbose


### PR DESCRIPTION
As far as I can grep, `names.scan()` alias `scan_external_dir()` is used nowhere and undocumented. There’s no test for it either.  I’ve read some old posts on mailing lists and tex-sx that would suggest was intended to be called  from fontspec. However, fontspec seems to do fine without it, so I guess we might as well drop the function.
