### PR TITLE
[letterspacing] restore unkerned state after exiting letterspaced region

### DIFF
--- a/luaotfload-letterspace.lua
+++ b/luaotfload-letterspace.lua
@@ -114,6 +114,7 @@ kerncharacters = function (head)
           kernfactors[fontid] = krn
         end
         if not krn or krn == 0 then
+          firstkern = true
           goto nextnode
         elseif firstkern then
           firstkern = false


### PR DESCRIPTION
Addendum to https://github.com/lualatex/luaotfload/issues/107
