### PR TITLE
[fontloader] patch glyph reorganization to avoid error

### DIFF
--- a/src/luaotfload-fontloader.lua
+++ b/src/luaotfload-fontloader.lua
@@ -8310,7 +8310,7 @@ actions["reorganize glyph anchors"]=function(data,filename,raw)
           for tag,specification in next,data do
             for i=1,#specification do
               local si=specification[i]
-              specification[i]={ si.x or 0,si.y or 0 }
+              specification[i]={ si and si.x or 0,si and si.y or 0 }
             end
           end
         else


### PR DESCRIPTION
This is a preliminary fix for https://github.com/lualatex/luaotfload/issues/248

It adds additional null checks, thereby suppressing the symptoms.
However, the real solution would probably have to tackle the actual
cause of the holes in the `specification` table in the first place.
