### PR TITLE
[main, aux] add a callback that installs a .resources table in fonts tha...

### DIFF
--- a/src/luaotfload-auxiliary.lua
+++ b/src/luaotfload-auxiliary.lua
@@ -129,6 +129,35 @@ luatexbase.add_to_callback(
   "luaotfload.patch_font",
   patch_cambria_domh,
   "luaotfload.aux.patch_cambria_domh")
+  
+
+--[[doc--
+
+  Add missing field to fonts that lack it. Addresses issue
+  https://github.com/lualatex/luaotfload/issues/253
+
+  This is considered a hack, especially since importing the
+  unicode-math package fixes the problem quite nicely.
+
+--doc]]--
+
+--- fontobj -> unit
+local fixup_fontdata = function (data)
+
+  local t = type (data)
+  --- Some OT fonts like Libertine R lack the resources table, causing
+  --- the fontloader to nil-index.
+  if t == "table" then
+    if data and not data.resources then data.resources = { } end
+  end
+
+end
+
+luatexbase.add_to_callback(
+  "luaotfload.patch_font_unsafe",
+  fixup_fontdata,
+  "luaotfload.aux.fixup_fontdata")
+  
 
 --[[doc--
 


### PR DESCRIPTION
...t it

Fixes https://github.com/lualatex/luaotfload/issues/253

Sort of.

In order to not interfere with the other callbacks which expect a sane
environment this hack got added by means of another callback that is
called whenever a defined font lacks essential subtables. This means
that the user must consider cases like numbers and partially defined
fonts. It’s best to keep both cases separate so those who aren’t
concerned with workarounds for weird fonts can stick with the clean
interface.
