### PR TITLE
colors: node processing routine rewritten 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 Change History
 --------------
 
-2014/XX/XX, luaotfload v2.6
+2015/0X/XX, luaotfload v2.6
     * Add ``sign`` target to makefile for automated package signing
     * Add ``--dumpconf`` option to luaotfload-tool for generating configuration
       files

--- a/doc/luaotfload-main.tex
+++ b/doc/luaotfload-main.tex
@@ -1,4 +1,4 @@
-%% Copyright (C) 2009-2014
+%% Copyright (C) 2009-2015
 %%
 %%      by  Elie Roux      <elie.roux@telecom-bretagne.eu>
 %%      and Khaled Hosny   <khaledhosny@eglug.org>
@@ -32,7 +32,7 @@
 \beginfrontmatter
 
   \setdocumenttitle  {The \identifier{luaotfload} package}
-  \setdocumentdate   {2014/07/13 v2.5}
+  \setdocumentdate   {2015/03/29 v2.6}
   \setdocumentauthor {Elie Roux · Khaled Hosny · Philipp Gesang\\
                       Home:    \hyperlink {https://github.com/lualatex/luaotfload}\\
                       Support: \email     {lualatex-dev@tug.org}}

--- a/doc/luaotfload.conf.rst
+++ b/doc/luaotfload.conf.rst
@@ -6,9 +6,9 @@
                      Luaotfload configuration file
 -----------------------------------------------------------------------
 
-:Date:                  2014-06-09
+:Date:                  2015-04-20
 :Copyright:             GPL v2.0
-:Version:               2.5
+:Version:               2.6
 :Manual section:        5
 :Manual group:          text processing
 
@@ -98,8 +98,9 @@ VARIABLES
 Variables in belong into a configuration section and their values must
 be of a certain type. Some of them have further constraints. For
 example, the “color callback” must be a string of one of the values
-``pre_linebreak_filter`` or ``pre_output_filter``, defined in the
-section *run*.
+``post_linebreak_filter``, ``pre_linebreak_filter``, or
+``pre_output_filter``, defined in the section *run* of the
+configuration file.
 
 Currently, the configuration is organized into four sections:
 
@@ -267,7 +268,7 @@ Section ``run``
 +------------------+--------+------------------------------+
 |  variable        |  type  |  default                     |
 +------------------+--------+------------------------------+
-|  color-callback  |   s    |  ``"pre_linebreak_filter"``  |
+|  color-callback  |   s    |  ``"post_linebreak_filter"`` |
 +------------------+--------+------------------------------+
 |  definer         |   s    |  ``"patch"``                 |
 +------------------+--------+------------------------------+
@@ -278,10 +279,14 @@ Section ``run``
 
 The ``color-callback`` option determines the stage at which fonts that
 defined with a ``color=xxyyzz`` feature will be colorized. By default
-this happens in a ``pre_linebreak_filter`` but alternatively the
-``pre_output_filter`` may be chosen, which is faster but might produce
-inconsistent output. The latter also was the default in the 1.x series
-of Luaotfload.
+this happens in a ``post_linebreak_filter`` but alternatively the
+``pre_linebreak_filter`` or ``pre_output_filter`` may be chosen, which
+is faster but might produce inconsistent output. The
+``pre_output_filter`` used to be the default in the 1.x series of
+Luaotfload, whilst later versions up to and including 2.5 hooked into
+the ``pre_linebreak_filter`` which naturally didn’t affect any glyphs
+inserting during hyphenation. Both are kept around as options to
+restore the previous behavior if necessary.
 
 The ``definer`` allows for switching the ``define_font`` callback.
 Apart from the default ``patch`` one may also choose the ``generic``

--- a/src/fontloader/luaotfload-package.lua
+++ b/src/fontloader/luaotfload-package.lua
@@ -1,0 +1,96 @@
+--
+-----------------------------------------------------------------------
+--         FILE:  luaotfload-package.lua
+--  DESCRIPTION:  Luatex fontloader packaging
+-- REQUIREMENTS:  luatex
+--       AUTHOR:  Philipp Gesang
+--      LICENSE:  GNU GPL v2.0
+--      CREATED:  2015-03-29 12:07:33+0200
+-----------------------------------------------------------------------
+--
+
+--- The original initialization sequence by Hans Hagen, see the file
+--- luatex-fonts.lua for details:
+---
+---   [01] l-lua.lua
+---   [02] l-lpeg.lua
+---   [03] l-function.lua
+---   [04] l-string.lua
+---   [05] l-table.lua
+---   [06] l-io.lua
+---   [07] l-file.lua
+---   [08] l-boolean.lua
+---   [09] l-math.lua
+---   [10] util-str.lua
+---   [11] luatex-basics-gen.lua
+---   [12] data-con.lua
+---   [13] luatex-basics-nod.lua
+---   [14] font-ini.lua
+---   [15] font-con.lua
+---   [16] luatex-fonts-enc.lua
+---   [17] font-cid.lua
+---   [18] font-map.lua
+---   [19] luatex-fonts-syn.lua
+---   [20] font-tfm.lua
+---   [21] font-afm.lua
+---   [22] font-afk.lua
+---   [23] luatex-fonts-tfm.lua
+---   [24] font-oti.lua
+---   [25] font-otf.lua
+---   [26] font-otb.lua
+---   [27] luatex-fonts-inj.lua
+---   [28] luatex-fonts-ota.lua
+---   [29] luatex-fonts-otn.lua
+---   [30] font-otp.lua
+---   [31] luatex-fonts-lua.lua
+---   [32] font-def.lua
+---   [33] luatex-fonts-def.lua
+---   [34] luatex-fonts-ext.lua
+---   [35] luatex-fonts-cbk.lua
+---
+--- Of these, nos. 01--10 are provided by the Lualibs. Keeping them
+--- around in the Luaotfload fontloader is therefore unnecessary.
+--- Packaging needs to account for this difference.
+
+loadmodule "l-lua.lua"
+loadmodule "l-lpeg.lua"
+loadmodule "l-function.lua"
+loadmodule "l-string.lua"
+loadmodule "l-table.lua"
+loadmodule "l-io.lua"
+loadmodule "l-file.lua"
+loadmodule "l-boolean.lua"
+loadmodule "l-math.lua"
+loadmodule "util-str.lua"
+
+--- The files below constitute the “fontloader proper”. Some of the
+--- functionality like file resolvers is overloaded later by
+--- Luaotfload. Consequently, the resulting package is pretty
+--- bare-bones and not usable independently.
+
+loadmodule("luatex-basics-gen.lua")
+loadmodule("data-con.lua")
+loadmodule("luatex-basics-nod.lua")
+loadmodule("font-ini.lua")
+loadmodule("font-con.lua")
+loadmodule("luatex-fonts-enc.lua")
+loadmodule("font-cid.lua")
+loadmodule("font-map.lua")
+loadmodule("luatex-fonts-syn.lua")
+loadmodule("font-tfm.lua")
+loadmodule("font-afm.lua")
+loadmodule("font-afk.lua")
+loadmodule("luatex-fonts-tfm.lua")
+loadmodule("font-oti.lua")
+loadmodule("font-otf.lua")
+loadmodule("font-otb.lua")
+loadmodule("luatex-fonts-inj.lua")
+loadmodule("luatex-fonts-ota.lua")
+loadmodule("luatex-fonts-otn.lua")
+loadmodule("font-otp.lua")
+loadmodule("luatex-fonts-lua.lua")
+loadmodule("font-def.lua")
+loadmodule("luatex-fonts-def.lua")
+loadmodule("luatex-fonts-ext.lua")
+loadmodule("luatex-fonts-cbk.lua")
+

--- a/src/fontloader/misc/fontloader-font-con.lua
+++ b/src/fontloader/misc/fontloader-font-con.lua
@@ -507,6 +507,7 @@ function constructors.scale(tfmdata,specification)
     local nonames          = properties.noglyphnames
     local haskerns         = properties.haskerns     or properties.mode == "base" -- we can have afm in node mode
     local hasligatures     = properties.hasligatures or properties.mode == "base" -- we can have afm in node mode
+    local realdimensions   = properties.realdimensions
     --
     if changed and not next(changed) then
         changed = false
@@ -618,6 +619,27 @@ function constructors.scale(tfmdata,specification)
         local width  = description.width
         local height = description.height
         local depth  = description.depth
+        if realdimensions then
+            -- this is mostly for checking issues
+            if not height or height == 0 then
+                local bb = description.boundingbox
+                local ht =  bb[4]
+                if ht ~= 0 then
+                    height = ht
+                end
+                if not depth or depth == 0 then
+                    local dp = -bb[2]
+                    if dp ~= 0 then
+                        depth = dp
+                    end
+                end
+            elseif not depth or depth == 0 then
+                local dp = -description.boundingbox[2]
+                if dp ~= 0 then
+                    depth = dp
+                end
+            end
+        end
         if width  then width  = hdelta*width  else width  = scaledwidth  end
         if height then height = vdelta*height else height = scaledheight end
     --  if depth  then depth  = vdelta*depth  else depth  = scaleddepth  end

--- a/src/fontloader/misc/fontloader-font-map.lua
+++ b/src/fontloader/misc/fontloader-font-map.lua
@@ -23,6 +23,8 @@ local fonts         = fonts or { }
 local mappings      = fonts.mappings or { }
 fonts.mappings      = mappings
 
+local allocate      = utilities.storage.allocate
+
 --[[ldx--
 <p>Eventually this code will disappear because map files are kind
 of obsolete. Some code may move to runtime or auxiliary modules.</p>
@@ -194,7 +196,7 @@ local namesplitter = Ct(C((1 - ligseparator - varseparator)^1) * (ligseparator *
 -- to be completed .. for fonts that use unicodes for ligatures which
 -- is a actually a bad thing and should be avoided in the first place
 
-local overloads = {
+local overloads = allocate {
     IJ  = { name = "I_J",   unicode = { 0x49, 0x4A },       mess = 0x0132 },
     ij  = { name = "i_j",   unicode = { 0x69, 0x6A },       mess = 0x0133 },
     ff  = { name = "f_f",   unicode = { 0x66, 0x66 },       mess = 0xFB00 },

--- a/src/fontloader/misc/fontloader-font-otf.lua
+++ b/src/fontloader/misc/fontloader-font-otf.lua
@@ -107,6 +107,7 @@ registerdirective("fonts.otf.loader.pack",          function(v) packdata      = 
 registerdirective("fonts.otf.loader.syncspace",     function(v) syncspace     = v end)
 registerdirective("fonts.otf.loader.forcenotdef",   function(v) forcenotdef   = v end)
 registerdirective("fonts.otf.loader.overloadkerns", function(v) overloadkerns = v end)
+-----------------("fonts.otf.loader.alldimensions", function(v) alldimensions = v end)
 
 function otf.fileformat(filename)
     local leader = lower(io.loadchunk(filename,4))
@@ -637,17 +638,27 @@ actions["add dimensions"] = function(data,filename)
          --     d.name = ".notdef"
          -- end
             if bb then
-                local ht, dp = bb[4], -bb[2]
-                if ht == 0 or ht < 0 then
-                    -- not set
-                else
-                    d.height = ht
-                end
-                if dp == 0 or dp < 0 then
-                    -- not set
-                else
-                    d.depth  = dp
-                end
+                local ht =  bb[4]
+                local dp = -bb[2]
+             -- if alldimensions then
+             --     if ht ~= 0 then
+             --         d.height = ht
+             --     end
+             --     if dp ~= 0 then
+             --         d.depth  = dp
+             --     end
+             -- else
+                    if ht == 0 or ht < 0 then
+                        -- not set
+                    else
+                        d.height = ht
+                    end
+                    if dp == 0 or dp < 0 then
+                        -- not set
+                    else
+                        d.depth  = dp
+                    end
+             -- end
             end
         end
     end

--- a/src/fontloader/misc/fontloader-l-math.lua
+++ b/src/fontloader/misc/fontloader-l-math.lua
@@ -8,6 +8,10 @@ if not modules then modules = { } end modules ['l-math'] = {
 
 local floor, sin, cos, tan = math.floor, math.sin, math.cos, math.tan
 
+if not math.ceiling then
+    math.ceiling = math.ceil
+end
+
 if not math.round then
     function math.round(x) return floor(x + 0.5) end
 end

--- a/src/luaotfload-auxiliary.lua
+++ b/src/luaotfload-auxiliary.lua
@@ -2,10 +2,10 @@
 -----------------------------------------------------------------------
 --         FILE:  luaotfload-auxiliary.lua
 --  DESCRIPTION:  part of luaotfload
--- REQUIREMENTS:  luaotfload 2.5
+-- REQUIREMENTS:  luaotfload 2.6
 --       AUTHOR:  Khaled Hosny, Élie Roux, Philipp Gesang
---      VERSION:  2.5
---     MODIFIED:  2014-01-02 21:24:25+0100
+--      VERSION:  2.6
+--     MODIFIED:  2015-03-29 12:43:26+0200
 -----------------------------------------------------------------------
 --
 

--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -270,12 +270,6 @@ node_colorize = function (head, current_color)
                 head, current_color = color_whatsit(head, n, current_color, false)
             end
 
-        elseif n_id == math_t and getsubtype(n) == 0 then
-            if current_color then
-                head, current_color = color_whatsit(head, n, current_color, false)
-            end
-            n = end_of_math(n)
-
         end
 
         n = getnext(n)

--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -193,7 +193,7 @@ lookup_next_color = function (head) --- paragraph material
             and identifiers[n_font].properties
             and identifiers[n_font].properties.color
             then
-                return identifiers[n.font].properties.color
+                return identifiers[n_font].properties.color
             else
                 return -1
             end

--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -188,7 +188,7 @@ lookup_next_color = function (head) --- paragraph material
         local n_id = n.id
 
         if n_id == glyph_t then
-            local n_font
+            local n_font = n.font
             if  identifiers[n_font]
             and identifiers[n_font].properties
             and identifiers[n_font].properties.color
@@ -285,13 +285,11 @@ local color_handler = function (head)
         end
         print""
         if t ~= "" then
-            print(">>", tpr, "<<")
             if not stringfind(tpr,"/ExtGState<<.*>>") then
                 tpr = tpr.."/ExtGState<<>>"
             end
             tpr = stringgsub(tpr,"/ExtGState<<","%1"..t)
             texset("global", "pdfpageresources", tpr)
-            print(">>", tpr, "<<")
         end
         res = nil -- reset res
     end

--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -283,7 +283,6 @@ local color_handler = function (head)
                 t = t .. str
             end
         end
-        print""
         if t ~= "" then
             if not stringfind(tpr,"/ExtGState<<.*>>") then
                 tpr = tpr.."/ExtGState<<>>"

--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -38,6 +38,9 @@ local nodetail              = nodedirect.tail
 local getattribute          = nodedirect.has_attribute
 local setattribute          = nodedirect.set_attribute
 
+local texset                = tex.set
+local texget                = tex.get
+
 local stringformat          = string.format
 
 local otffeatures           = fonts.constructors.newfeatures("otf")
@@ -301,9 +304,6 @@ node_colorize = function (head, current_color)
     return head, current_color
 end
 
-local get_page_res = pdf.getpageresources or function() return pdf.pageresources end
-local set_page_res = pdf.setpageresources or function(s) pdf.pageresources = s end
-
 --- node -> node
 local color_handler = function (head)
     head = todirect(head)
@@ -313,7 +313,7 @@ local color_handler = function (head)
     -- now append our page resources
     if res then
         res["1"]  = true
-        local tpr = get_page_res() or ""
+        local tpr = texget("pdfpageresources") -- respect other packages. we need a guidance
         local t   = ""
         for k in pairs(res) do
             local str = stringformat("/TransGs%s<</ca %s>>", k, k) -- don't touch stroking elements
@@ -326,7 +326,7 @@ local color_handler = function (head)
                 tpr = tpr .. "/ExtGState<<>>"
             end
             tpr = tpr:gsub("/ExtGState<<", "%1"..t)
-            set_page_res(tpr) -- always global
+            texset("global", "pdfpageresources", tpr)
         end
         res = nil -- reset res
     end

--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -183,8 +183,6 @@ local glyph_t           = nodetype("glyph")
 local hlist_t           = nodetype("hlist")
 local vlist_t           = nodetype("vlist")
 local whatsit_t         = nodetype("whatsit")
--- local page_insert_t     = nodetype("page_insert")
-local sub_box_t         = nodetype("sub_box")
 local disc_t            = nodetype("disc")
 local pdfliteral_t      = node.subtype("pdf_literal")
 local colorstack_t      = node.subtype("pdf_colorstack")
@@ -234,7 +232,7 @@ node_colorize = function (head, current_color)
     while n do
         local n_id = getid(n)
 
-        if n_id == hlist_t or n_id == vlist_t or n_id == sub_box_t then
+        if n_id == hlist_t or n_id == vlist_t then
             cnt = cnt + 1
             local n_list = getlist(n)
             if getattribute(n_list, color_attr) then

--- a/src/luaotfload-configuration.lua
+++ b/src/luaotfload-configuration.lua
@@ -2,10 +2,10 @@
 -------------------------------------------------------------------------------
 --         FILE:  luaotfload-configuration.lua
 --  DESCRIPTION:  config file reader
--- REQUIREMENTS:  Luaotfload 2.5 or above
+-- REQUIREMENTS:  Luaotfload 2.6 or above
 --       AUTHOR:  Philipp Gesang (Phg), <phg42.2a@gmail.com>
 --      VERSION:  same as Luaotfload
---     MODIFIED:  2015-03-16 07:48:58+0100
+--     MODIFIED:  2015-03-29 12:46:43+0200
 -------------------------------------------------------------------------------
 --
 
@@ -142,6 +142,23 @@ local registered_loaders = {
   default    = "fontloader",
   fontloader = "fontloader",
   tl2013     = "tl2013",
+}
+
+--[[doc--
+
+  The ``post_linebreak_filter`` has been made the default callback for
+  hooking the colorizer into. This helps with the linebreaking whose
+  inserted hyphens would remain unaffected by the coloring otherwise.
+
+  http://tex.stackexchange.com/q/238539/14066
+
+--doc]]--
+
+local permissible_color_callbacks = {
+  default               = "post_linebreak_filter",
+  pre_linebreak_filter  = "pre_linebreak_filter",
+  post_linebreak_filter = "post_linebreak_filter",
+  pre_output_filter     = "pre_output_filter",
 }
 
 
@@ -479,9 +496,20 @@ local option_spec = {
     color_callback = {
       in_t      = string_t,
       out_t     = string_t,
-      transform = function (cb)
+      transform = function (cb_spec)
         --- These are the two that make sense.
-        return cb == "pre_output_filter" and cb or "pre_linebreak_filter"
+        local cb = permissible_color_callbacks[cb_spec]
+        if cb then
+          logreport ("log", 3, "conf",
+                     "Using callback \"%s\" for font colorization.",
+                     cb)
+          return cb
+        end
+        logreport ("log", 0, "conf",
+                    "Requested callback identifier \"%s\" invalid, "
+                    .. "falling back to default.",
+                    cb_spec)
+        return permissible_color_callbacks.default
       end,
     },
   },

--- a/src/luaotfload-main.lua
+++ b/src/luaotfload-main.lua
@@ -1,10 +1,10 @@
 -----------------------------------------------------------------------
 --         FILE:  luaotfload-main.lua
 --  DESCRIPTION:  Luatex fontloader initialization
--- REQUIREMENTS:  luatex v.0.79 or later; packages lualibs, luatexbase
+-- REQUIREMENTS:  luatex v.0.80 or later; packages lualibs, luatexbase
 --       AUTHOR:  Élie Roux, Khaled Hosny, Philipp Gesang
 --      VERSION:  same as Luaotfload
---     MODIFIED:  2015-03-11 07:49:20+0100
+--     MODIFIED:  2015-03-29 12:41:09+0200
 -----------------------------------------------------------------------
 --
 --- Note:
@@ -14,7 +14,7 @@
 --- markup.
 
 if not modules then modules = { } end modules ["luaotfload-main"] = {
-    version   = "2.5",
+    version   = "2.6",
     comment   = "fontloader initialization",
     author    = "Hans Hagen, Khaled Hosny, Elie Roux, Philipp Gesang",
     copyright = "PRAGMA ADE / ConTeXt Development Team",
@@ -48,12 +48,12 @@ local initial_log_level = 0
 luaotfload                        = luaotfload or { }
 local luaotfload                  = luaotfload
 luaotfload.log                    = luaotfload.log or { }
-luaotfload.version                = "2.5-2" -- FIXME version belongs in common init
+luaotfload.version                = "2.6" -- FIXME version belongs in common init
 
 luaotfload.module = {
     name          = "luaotfload-main",
-    version       = 2.50001,
-    date          = "2014/07/16",
+    version       = 2.60000,
+    date          = "2015/03/29",
     description   = "OpenType layout system.",
     author        = "Elie Roux & Hans Hagen",
     copyright     = "Elie Roux",

--- a/src/luaotfload-tool.lua
+++ b/src/luaotfload-tool.lua
@@ -2,15 +2,15 @@
 -----------------------------------------------------------------------
 --         FILE:  luaotfload-tool.lua
 --  DESCRIPTION:  database functionality
--- REQUIREMENTS:  luaotfload 2.5
+-- REQUIREMENTS:  luaotfload 2.6
 --       AUTHOR:  Khaled Hosny, Élie Roux, Philipp Gesang
---      VERSION:  2.5
+--      VERSION:  2.6
 --      LICENSE:  GPL v2.0
---     MODIFIED:  2014-07-24 22:10:32+0200
+--     MODIFIED:  2015-03-29 12:43:00+0200
 -----------------------------------------------------------------------
 
 luaotfload          = luaotfload or { }
-local version       = "2.5-2" --- <int: major>.<int: minor>-<int: fixes>
+local version       = "2.6"
 luaotfload.version  = version
 luaotfload.self     = "luaotfload-tool"
 

--- a/src/luaotfload.sty
+++ b/src/luaotfload.sty
@@ -1,4 +1,4 @@
-%% Copyright (C) 2009-2014
+%% Copyright (C) 2009-2015
 %%
 %%      by  Elie Roux      <elie.roux@telecom-bretagne.eu>
 %%      and Khaled Hosny   <khaledhosny@eglug.org>
@@ -40,7 +40,7 @@
   \ProvidesPackage{luaotfload}%
     %% FIXME  The date is meaningless, we need to find a way to
     %%        use the git revision instead.
-    [2014/07/24 v2.5-2 OpenType layout system]
+    [2015/03/29 v2.6 OpenType layout system]
   \RequirePackage{luatexbase}
 \fi
 \RequireLuaModule{luaotfload-main}


### PR DESCRIPTION
* used `node.direct` mode
* address an issue regarding page break
 - upon `post_linebreak_filter` or `pre_output_filter`, color pop nodes will be inserted at every linebreak.
 - upon `pre_linebreak_filter`, color pop nodes will be  inserted at every glyph sequence boundary. 
* default callback is now `post_linebreak_filter`, which seems to be much better than any other.
* some node lists are not captures by above-mentioned callbacks. So `hpack_filter` is used as well.
* for compatibility with (x)color packages, `pdf_colorstack` node will be used; `pdf_literal` node is stil used for turning transparency off.