### PR TITLE
Patch to not assume luatexbase needs to be loaded

### DIFF
--- a/src/luaotfload-main.lua
+++ b/src/luaotfload-main.lua
@@ -249,7 +249,9 @@ do
     definers.info_generic   = mk_info "generic"
 end
 
-reset_callback "define_font"
+if not reset_callback == nil then
+  reset_callback "define_font"
+end
 
 --[[doc--
 

--- a/src/luaotfload.sty
+++ b/src/luaotfload.sty
@@ -35,16 +35,24 @@
 \let\ifluaotfloadloaded\endinput
 \bgroup\expandafter\expandafter\expandafter\egroup
 \expandafter\ifx\csname selectfont\endcsname\relax
+ \ifdefined\newluafunction\else
   \input luatexbase.sty
+ \fi
 \else
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luaotfload}%
     %% FIXME  The date is meaningless, we need to find a way to
     %%        use the git revision instead.
     [2015/03/29 v2.6 OpenType layout system]
-  \RequirePackage{luatexbase}
+ \ifdefined\newluafunction\else
+    \RequirePackage{luatexbase}
+ \fi
 \fi
-\RequireLuaModule{luaotfload-main}
+\ifdefined \RequireLuaModule
+ \RequireLuaModule{luaotfload-main}
+\else
+  \directlua{require("luaotfload-main")}
+\fi
 
 % for compatibility with beamer class, which loads pgf package.
 \ifcsname selectfont\endcsname


### PR DESCRIPTION
Hi, 
I wonder if you would consider this pull request to ease use of luaotfload
in planned future latex formats that might have (a version of) the luatexbase support
built in and so would not require luatexbase being loaded.


The ltluatex code being trialed at

https://github.com/josephwright/ltluatex

includes a luatexbase emulation package that allows
luaotfload to run without change but the core code that
is intended to be included in future latex formats requires
two small changes and also would require that luaotfload
detect that luatex support is already provided and so not
load luatexbase.

\RequireLuaModule is not defined by default in TeX and
luatexbase.reset_callback is not defined by default in lua
in the core ltluatex code.