### PR TITLE
Remove loading of luatexbae "loader" submodule

### DIFF
--- a/src/luaotfload-tool.lua
+++ b/src/luaotfload-tool.lua
@@ -80,16 +80,9 @@ end
 local C, Ct, P, S  = lpeg.C, lpeg.Ct, lpeg.P, lpeg.S
 local lpegmatch    = lpeg.match
 
-local loader_file = "luatexbase.loader.lua"
-local loader_path = assert(kpsefind_file(loader_file, "lua"),
-                           "File '"..loader_file.."' not found")
-
-
 string.quoted = string.quoted or function (str)
   return string.format("%q",str) 
 end
-
-require (loader_path)
 
 --[[doc--
 


### PR DESCRIPTION
The team are now managing LuaTeX support directly and `luatexbase` is a stub. Moreover, the need for the `loader` submodule has not been around for some time, and that code has not been carried forward at all. The best thing is therefore to drop this entirely.