### PR TITLE
define priority_in_callback (from luatexbase)

### DIFF
--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -315,7 +315,16 @@ end
 
 local color_callback_activated = 0
 local add_to_callback          = luatexbase.add_to_callback
-local priority_in_callback     = luatexbase.priority_in_callback
+local function priority_in_callback (name,description)
+  for i,v in ipairs(luatexbase.callback_descriptions(name))
+  do
+    if v == description then
+      return i
+    end
+  end
+  return false
+end
+
 
 --- unit -> unit
 add_color_callback = function ( )

--- a/src/luaotfload.sty
+++ b/src/luaotfload.sty
@@ -33,7 +33,7 @@
 %%
 \csname ifluaotfloadloaded\endcsname
 \let\ifluaotfloadloaded\endinput
-\ifx\newluafunction\@undefined
+\ifx\newluafunction\undefined
   \input ltluatex
 \fi
 \ifdefined\ProvidesPackage


### PR DESCRIPTION
Sorry the color support uses priority_in_callback which is in luatexbase but not ltluatex
This just copies the definition as a local function