### PR TITLE
@ may not be catcode 11 in plain

### DIFF
--- a/src/luaotfload.sty
+++ b/src/luaotfload.sty
@@ -33,7 +33,7 @@
 %%
 \csname ifluaotfloadloaded\endcsname
 \let\ifluaotfloadloaded\endinput
-\ifx\newluafunction\@undefined
+\ifx\newluafunction\undefined
   \input ltluatex
 \fi
 \ifdefined\ProvidesPackage


### PR DESCRIPTION
as suggested by @dohyunkim don't use `@`  here.