### PR TITLE
[init] typo

### DIFF
--- a/src/luaotfload-init.lua
+++ b/src/luaotfload-init.lua
@@ -366,7 +366,7 @@ local init_main = function ()
     local _void = require (fontloader)
 
   elseif kpselookup (fontloader) then
-    local pth = kpselookup (fontloader)
+    local path = kpselookup (fontloader)
     logreport ("both", 2, "init",
                "Attempting to load fontloader “%s” from kpse-resolved path “%s”.",
                fontloader, path)


### PR DESCRIPTION
After upgrade to luaotfload v2.6-rc3, I've encountered an error which probably seems to be attributable to a small typo in `luaotfload-init.lua`. 