### PR TITLE
Move initialization to the Lua module itself

### DIFF
--- a/src/luaotfload-main.lua
+++ b/src/luaotfload-main.lua
@@ -222,46 +222,43 @@ local install_loaders = function ()
     return loaders
 end
 
-luaotfload.main = function ()
+luaotfload.loaders = install_loaders ()
+local loaders    = luaotfload.loaders
+local loadmodule = loaders.luaotfload
+local initialize = loaders.initialize
 
-    luaotfload.loaders = install_loaders ()
-    local loaders    = luaotfload.loaders
-    local loadmodule = loaders.luaotfload
-    local initialize = loaders.initialize
+local starttime = osgettimeofday ()
+local init      = loadmodule "init" --- fontloader initialization
+local store     = init.early ()     --- injects the log module too
+local logreport = luaotfload.log.report
 
-    local starttime = osgettimeofday ()
-    local init      = loadmodule "init" --- fontloader initialization
-    local store     = init.early ()     --- injects the log module too
-    local logreport = luaotfload.log.report
+initialize "parsers"         --- fonts.conf and syntax
+initialize "configuration"   --- configuration options
 
-    initialize "parsers"         --- fonts.conf and syntax
-    initialize "configuration"   --- configuration options
-
-    if not init.main (store) then
-        logreport ("log", 0, "load", "Main fontloader initialization failed.")
-    end
-
-    initialize "loaders"         --- Font loading; callbacks
-    initialize "database"        --- Font management.
-    initialize "colors"          --- Per-font colors.
-
-    luaotfload.resolvers = loadmodule "resolvers" --- Font lookup
-    luaotfload.resolvers.init ()
-
-    if not config.actions.reconfigure () then
-        logreport ("log", 0, "load", "Post-configuration hooks failed.")
-    end
-
-    initialize "features"     --- font request and feature handling
-    loadmodule "letterspace"  --- extra character kerning
-    initialize "auxiliary"    --- additional high-level functionality
-
-    luaotfload.aux.start_rewrite_fontname () --- to be migrated to fontspec
-
-    logreport ("both", 0, "main",
-               "initialization completed in %0.3f seconds",
-               osgettimeofday() - starttime)
-----inspect (timing_info)
+if not init.main (store) then
+  logreport ("log", 0, "load", "Main fontloader initialization failed.")
 end
+
+initialize "loaders"         --- Font loading; callbacks
+initialize "database"        --- Font management.
+initialize "colors"          --- Per-font colors.
+
+luaotfload.resolvers = loadmodule "resolvers" --- Font lookup
+luaotfload.resolvers.init ()
+
+if not config.actions.reconfigure () then
+  logreport ("log", 0, "load", "Post-configuration hooks failed.")
+end
+
+initialize "features"     --- font request and feature handling
+loadmodule "letterspace"  --- extra character kerning
+initialize "auxiliary"    --- additional high-level functionality
+
+luaotfload.aux.start_rewrite_fontname () --- to be migrated to fontspec
+
+logreport ("both", 0, "main",
+			"initialization completed in %0.3f seconds",
+			osgettimeofday() - starttime)
+----inspect (timing_info)
 
 -- vim:tw=79:sw=4:ts=4:et

--- a/src/luaotfload.sty
+++ b/src/luaotfload.sty
@@ -43,8 +43,4 @@
     %%        use the git revision instead.
     [2015/12/09 v2.6  OpenType layout system]
 \fi
-\directlua{
-require('luaotfload-main')
-local _void = luaotfload.main ()
-}
-
+\directlua{require('luaotfload-main')}


### PR DESCRIPTION
Currently, `luaotfload.sty` loads the `luaotfload-main` Lua module and then (inmediatly) runs an initialization function (`luaotfload.main()`) offered by this module. This function is, in fact, never run again, and isn't intended to be run more than once, AFAICT.

Instead, do initialization directly in the Lua module, straight away.

Motivation behind this change:
One may want to dump a custom format (with LuaTeX). In order to make it feasible and useful, one has to dump all Lua modules in the format. To do this, one could hook into `require`'s second searcher so as to save the loader function that it gets in a bytecode register. However, with the current state of affairs, this approach fails to save the initialization step done by calling `luaotfload.main()`. This can be solved by moving initialization to the Lua module itself.