### PR TITLE
Avoid more than one `inrange` when there’s no overlap

### DIFF
--- a/src/luaotfload-database.lua
+++ b/src/luaotfload-database.lua
@@ -928,7 +928,7 @@ local choose_size = function (sizes, askedsize)
                 --- exact match, this is what we were looking for
                 exact = index
                 goto skip
-            elseif askedsize < low then
+            elseif askedsize <= low then
                 --- below range, add to the norange table
                 local d = low - askedsize
                 norange [#norange + 1] = { d, index }


### PR DESCRIPTION
The original will lead to more than one matched range even when there's no overlap among size ranges. This will happen when the asked size is exactly on the boundary (*without any rounding errors*).

If we strictly stick to the definition of optical range as in an Open-Closed interval, then this will lead to incorrect behavior.

But I am in doubt of this. The OpenType optical range is specified as Open-Closed, so that there's no overlap between adjacent intervals. However, say one is `(3, 5]` with design size `4`, and another is `(5, 6]` with design size `5.5`. At 5 point, the strict interpretation leads to `(3, 5]`, which is the result of this pull request. However, it is closer to `5.5`, the design size of the next range. It makes perfect sense to select the "wrong" interval to get *better* results.

This issue did not shown in previous tests I had done, because without #400, and all previous versions, there's always some rounding error. Admittedly they are extremely small (less than 1sp). Yet it prevented the situation where an asked size is *exactly* on boundary.

Also, for most optical fonts (not many out there anyway), this pull request makes no difference. Since in most optical fonts, the intervals get larger as the design size grows. So by measuring distance as `asked size - center of interval`, it's always closer to the lower range. And thus the upper bound of the it will be chosen anyway, even if there's two matched ones.

This only become a problem with fonts with very dense partitions among small sizes, and results in a lower range have a bigger interval than the next one. I only know LM and Arno have such issues. 