### PR TITLE
use design size to calculate the distance for `inrange`

### DIFF
--- a/src/luaotfload-database.lua
+++ b/src/luaotfload-database.lua
@@ -938,10 +938,19 @@ local choose_size = function (sizes, askedsize)
                 norange [#norange + 1] = { d, index }
             else
                 --- range match
-                local d = ((low + high) / 2) - askedsize
+                local d = 0
+
+                -- should always be true. Just in case there's some
+                -- weried fonts out there
+                if dsnsize > low and dsnsize < high then
+                    d = dsnsize - askedsize
+                else
+                    d = ((low + high) / 2) - askedsize
+                end
                 if d < 0 then
                     d = -d
                 end
+
                 inrange [#inrange + 1] = { d, index }
             end
         end


### PR DESCRIPTION
This is not a bug-fix but rather a change of behavior for your consideration.

The original measure distance from asked size to the center of the ranges. However, it might be better to calculate the distance to the design size, that is the size at which the font looks best.

With #401, this pull request will only have effect when there are overlapped ranges. I don't know any fonts have such. But 1) There might be some out there, 2) The user can always patch database to make it so. And this actually makes sense. By making adjacent intervals overlap some, it allows, one to automatically choose a font with closest design size instead of sticking to the somehow mechanical portion of ranges. For example, one can have,
```
(3, 4.5], design size 4
(4, 5.5], design size 5
...
```
(Actually I do something similar when using optical fonts)
Then withn the whole range `(3, 5.5]`, we will always choose the one with closest design size.